### PR TITLE
Bump package to Laravel 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
     ],
     "require": {
         "php": "^7.2",
-        "illuminate/support": "^5.4|^6.0",
-        "illuminate/database": "^5.4|^6.0",
-        "illuminate/filesystem": "^5.4|^6.0",
-        "illuminate/console": "^5.4|^6.0"
+        "illuminate/support": "^5.4|^6.0|^7.0",
+        "illuminate/database": "^5.4|^6.0|^7.0",
+        "illuminate/filesystem": "^5.4|^6.0|^7.0",
+        "illuminate/console": "^5.4|^6.0|^7.0"
     },
     "require-dev": {
         "mockery/mockery": "@stable",


### PR DESCRIPTION
yesterday was Laravel 7 released. With this PR we can support the latest version of Laravel.

PS. Don't forget to publish a new realese after merging this PR.